### PR TITLE
fix:布局动画配置未校验是否为空问题修复

### DIFF
--- a/src/KeyboardAccessoryView.js
+++ b/src/KeyboardAccessoryView.js
@@ -122,7 +122,7 @@ class KeyboardAccessoryView extends Component {
     const { animateOn, animationConfig } = this.props;
 
     if (animateOn === 'all' || Platform.OS === animateOn) {
-      LayoutAnimation.configureNext(
+      animationConfig || LayoutAnimation.configureNext(
         accessoryAnimation(keyboardEvent.duration, keyboardEvent.easing, animationConfig)
       );
     }


### PR DESCRIPTION
# Summary

本次提交是为了修复布局动画配置未校验问题，close #8。
此次修改添加了动画配置是否存在的判断：在调用LayoutAnimation.configureNext方法的时候，判断animationConfig是否存在，如果存在才会调用LayoutAnimation.configureNext方法，此次修改不会影响原先功能。

## Test Plant

![截图2](https://github.com/user-attachments/assets/de635d59-789c-4c13-8160-2620f8b5644f)

## Checklist
<!-- 检查项, 请自行排查并打钩, 通过: [X] -->

- [X] 已经在真机设备或模拟器上测试通过
- [X] 已经与 Android 或 iOS 平台做过效果/功能对比
- [X] 已经添加了对应 API 的测试用例
- [ ] 已经更新了文档
- [X] 更新了 JS/TS 代码
